### PR TITLE
Add homelab showcase section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import ProfileSection from "@/components/profile-section"
 import SkillsSection from "@/components/skills-section"
 import ProjectsSection from "@/components/projects-section"
+import HomelabSection from "@/components/homelab-section"
 import ExperienceSection from "@/components/experience-section"
 import BlogSection from "@/components/blog-section"
 import {getSortedBlogPosts} from "@/lib/blogs"
@@ -13,6 +14,7 @@ export default function Home() {
             <ProfileSection/>
             <SkillsSection/>
             <ProjectsSection/>
+            <HomelabSection/>
             <ExperienceSection/>
             <BlogSection posts={allPosts}/>
         </div>

--- a/components/homelab-section.tsx
+++ b/components/homelab-section.tsx
@@ -43,8 +43,17 @@ export default function HomelabSection() {
                                 return (
                                     <div
                                         key={service.id}
+                                        role="button"
+                                        tabIndex={0}
+                                        aria-expanded={isExpanded}
                                         onClick={() => setExpandedId(isExpanded ? null : service.id)}
-                                        className={`cursor-pointer bg-secondary/20 border border-border rounded-lg overflow-hidden transition-all duration-300 hover:border-accent/30 ${
+                                        onKeyDown={(e) => {
+                                            if (e.key === "Enter" || e.key === " ") {
+                                                e.preventDefault()
+                                                setExpandedId(isExpanded ? null : service.id)
+                                            }
+                                        }}
+                                        className={`cursor-pointer bg-secondary/20 border border-border rounded-lg overflow-hidden transition-all duration-300 hover:border-accent/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent ${
                                             isExpanded ? 'col-span-2 bg-secondary/30' : ''
                                         }`}
                                     >

--- a/components/homelab-section.tsx
+++ b/components/homelab-section.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import {useState} from "react"
+import {homelabServices, categoryColors} from "@/data/homelab"
+import {Badge} from "@/components/ui/badge"
+import {ChevronDown} from "lucide-react"
+
+export default function HomelabSection() {
+    const [isOpen, setIsOpen] = useState(false)
+    const [expandedId, setExpandedId] = useState<string | null>(null)
+
+    return (
+        <section id="homelab" className="py-6 px-4">
+            <div className="max-w-2xl mx-auto">
+                {/* Section Header — clickable to collapse/expand */}
+                <button
+                    onClick={() => {
+                        setIsOpen(!isOpen)
+                        if (isOpen) setExpandedId(null)
+                    }}
+                    className="w-full flex items-center justify-between mb-4 hover:text-accent transition-colors duration-300"
+                >
+                    <div className="flex items-center gap-2">
+                        <h2 className="text-lg font-semibold">Homelab</h2>
+                        <span className="text-xs font-mono bg-secondary/50 px-2 py-0.5 rounded-full">{homelabServices.length}</span>
+                    </div>
+                    <ChevronDown
+                        size={18}
+                        className={`text-muted-foreground transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`}
+                    />
+                </button>
+                <p className={`text-xs text-muted-foreground ${isOpen ? 'mb-4' : ''} -mt-3`}>
+                    Proxmox VE cluster with Docker stacks behind Caddy + CrowdSec WAF
+                </p>
+
+                {isOpen && (
+                    <>
+                        {/* Services Grid */}
+                        <div className="grid grid-cols-2 gap-3 animate-fade-in">
+                            {homelabServices.map((service) => {
+                                const isExpanded = expandedId === service.id
+
+                                return (
+                                    <div
+                                        key={service.id}
+                                        onClick={() => setExpandedId(isExpanded ? null : service.id)}
+                                        className={`cursor-pointer bg-secondary/20 border border-border rounded-lg overflow-hidden transition-all duration-300 hover:border-accent/30 ${
+                                            isExpanded ? 'col-span-2 bg-secondary/30' : ''
+                                        }`}
+                                    >
+                                        {/* Compact View */}
+                                        <div className="p-3">
+                                            <div className="flex items-center justify-between mb-1">
+                                                <div className="flex items-center gap-2 min-w-0">
+                                                    <span className="text-sm flex-shrink-0">{service.icon}</span>
+                                                    <h3 className="text-sm font-medium truncate">{service.title}</h3>
+                                                </div>
+                                                <div className="flex items-center gap-1.5 flex-shrink-0 ml-2">
+                                                    <span className={`text-xs px-1.5 py-0.5 rounded border ${categoryColors[service.category]}`}>
+                                                        {service.category}
+                                                    </span>
+                                                    <ChevronDown
+                                                        size={14}
+                                                        className={`text-muted-foreground transition-transform duration-300 ${isExpanded ? 'rotate-180' : ''}`}
+                                                    />
+                                                </div>
+                                            </div>
+
+                                            {!isExpanded && (
+                                                <p className="text-xs text-muted-foreground line-clamp-2">
+                                                    {service.description}
+                                                </p>
+                                            )}
+                                        </div>
+
+                                        {/* Expanded View */}
+                                        {isExpanded && (
+                                            <div className="px-3 pb-3 border-t border-border/50 animate-fade-in">
+                                                <p className="text-xs text-muted-foreground mb-3 leading-relaxed">
+                                                    {service.description}
+                                                </p>
+
+                                                {/* Tech Stack */}
+                                                <div className="flex flex-wrap gap-1 mb-3">
+                                                    {service.technologies.map((tech) => (
+                                                        <Badge key={tech} variant="secondary" className="text-xs font-mono">
+                                                            {tech}
+                                                        </Badge>
+                                                    ))}
+                                                </div>
+
+                                                {/* Features */}
+                                                <div>
+                                                    <p className="text-xs font-mono text-accent mb-1">Features</p>
+                                                    <ul className="space-y-0.5">
+                                                        {service.features.map((feature, idx) => (
+                                                            <li key={idx} className="text-xs text-muted-foreground flex items-start gap-1.5">
+                                                                <span className="text-accent">›</span>
+                                                                <span>{feature}</span>
+                                                            </li>
+                                                        ))}
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        )}
+                                    </div>
+                                )
+                            })}
+                        </div>
+
+                        {/* Uptime Kuma Status Embed */}
+                        {expandedId === "uptime-kuma" && (
+                            <div className="mt-4 rounded-lg border border-border overflow-hidden animate-fade-in">
+                                <div className="px-3 py-2 bg-secondary/30 border-b border-border/50">
+                                    <p className="text-xs font-mono text-muted-foreground">Live Status — Uptime Kuma</p>
+                                </div>
+                                <iframe
+                                    src="https://status.homelab.seif-dx.com/status/homelab"
+                                    title="Homelab Uptime Status"
+                                    className="w-full h-[300px] bg-background"
+                                    loading="lazy"
+                                />
+                            </div>
+                        )}
+                    </>
+                )}
+            </div>
+        </section>
+    )
+}

--- a/components/homelab-section.tsx
+++ b/components/homelab-section.tsx
@@ -36,7 +36,7 @@ export default function HomelabSection() {
                 {isOpen && (
                     <>
                         {/* Services Grid */}
-                        <div className="grid grid-cols-2 gap-3 animate-fade-in">
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 animate-fade-in">
                             {homelabServices.map((service) => {
                                 const isExpanded = expandedId === service.id
 
@@ -125,6 +125,7 @@ export default function HomelabSection() {
                                 </div>
                                 <iframe
                                     src="https://status.homelab.seif-dx.com/status/homelab"
+                                    sandbox="allow-scripts allow-same-origin"
                                     title="Homelab Uptime Status"
                                     className="w-full h-[300px] bg-background"
                                     loading="lazy"

--- a/components/profile-section.tsx
+++ b/components/profile-section.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image"
 import {Github, Linkedin, Mail, Calendar, Zap, Route, Atom, Wind, Database, Shield} from "lucide-react"
-import {githubLink, linkedInLink, calendlyLink} from "@/lib/links"
-import {SITE_CONFIG} from "@/lib/constants"
+import {SITE_CONFIG, LINKS} from "@/lib/constants"
 
 const techStack = [
     { name: "ElysiaJS", icon: Zap, color: "text-yellow-400" },
@@ -73,7 +72,7 @@ export default function ProfileSection() {
                 {/* Social Icons - Compact */}
                 <div className="flex items-center gap-2">
                     <a 
-                        href={githubLink} 
+                        href={LINKS.GITHUB} 
                         target="_blank" 
                         rel="noopener noreferrer"
                         className="w-8 h-8 flex items-center justify-center rounded-lg bg-secondary/30 border border-border text-muted-foreground hover:text-accent hover:border-accent/30 transition-all duration-300"
@@ -82,7 +81,7 @@ export default function ProfileSection() {
                         <Github size={16} />
                     </a>
                     <a 
-                        href={linkedInLink} 
+                        href={LINKS.LINKEDIN} 
                         target="_blank" 
                         rel="noopener noreferrer"
                         className="w-8 h-8 flex items-center justify-center rounded-lg bg-secondary/30 border border-border text-muted-foreground hover:text-accent hover:border-accent/30 transition-all duration-300"
@@ -98,7 +97,7 @@ export default function ProfileSection() {
                         <Mail size={16} />
                     </a>
                     <a 
-                        href={calendlyLink} 
+                        href={LINKS.CALENDLY} 
                         target="_blank" 
                         rel="noopener noreferrer"
                         className="w-8 h-8 flex items-center justify-center rounded-lg bg-secondary/30 border border-border text-muted-foreground hover:text-accent hover:border-accent/30 transition-all duration-300"

--- a/data/blogs/homelab-setup.mdx
+++ b/data/blogs/homelab-setup.mdx
@@ -59,7 +59,7 @@ Proxmox's built-in vzdump runs daily at 2 AM, creating full snapshots of every V
 
 I follow the 3-2-1 backup rule:
 - **3 copies** of all critical data
-- **2 different media types** (NVMe + USB HDD + PBS)
+- **2 different media types** (NVMe + USB HDD, managed via Proxmox Backup Server)
 - **1 offsite** backup (encrypted, pushed to remote storage)
 
 Retention policies keep daily backups for 7 days, weekly for 4 weeks, and monthly for 6 months.

--- a/data/blogs/homelab-setup.mdx
+++ b/data/blogs/homelab-setup.mdx
@@ -1,0 +1,154 @@
+---
+title: "My Homelab: A Tour of My Self-Hosted Infrastructure"
+date: "22-02-2026"
+excerpt: "A walkthrough of my Proxmox-based homelab — from network architecture and Docker stacks to automated backups, DNS filtering, and security hardening with CrowdSec."
+tags: ["Homelab", "Self-Hosting", "Proxmox", "Docker", "Infrastructure"]
+---
+
+What started as an N100 mini PC experiment quickly grew into a full self-hosted infrastructure running 24/7 from my home. This post is a tour of everything running on my Proxmox VE homelab — the architecture, the services, the security, and the backup strategy that keeps it all safe.
+
+## Why I Built This
+
+I wrote about my motivation in a [previous post](/blog/self-hosting-2026). The short version: I wanted full control over my data, wanted to stop paying cloud providers for things I can run myself, and wanted to build real infrastructure skills. A few months in, the homelab has exceeded every expectation.
+
+## Hardware Overview
+
+The entire stack runs on a single Proxmox VE host:
+
+- **CPU**: 16 cores
+- **RAM**: 30 GB
+- **Storage**: 4 TB USB HDD for bulk data, NVMe for OS and VMs
+- **Network**: Dual bridge — vmbr0 for LAN, vmbr1 for private NAT (10.10.10.0/24)
+
+Proxmox VE acts as a type-1 hypervisor, managing both LXC containers (lightweight, for single-purpose services) and full VMs (for Docker workloads).
+
+## Network Architecture
+
+The network design separates concerns cleanly:
+
+**vmbr0 (LAN Bridge)** — Connects containers and VMs to the home network. Services that need to be reachable from other devices on the LAN use this bridge.
+
+**vmbr1 (Private NAT — 10.10.10.0/24)** — An isolated network for inter-service communication. Services on this bridge can talk to each other but aren't directly accessible from the LAN unless explicitly routed.
+
+**DNS Forwarding** — iptables DNAT rules on the Proxmox host redirect all DNS traffic (port 53) to AdGuard Home, ensuring every device on the network benefits from DNS filtering regardless of its configured DNS server.
+
+## Automated Backups
+
+Backups are the most important part of any homelab. I run two complementary backup systems:
+
+### Borgmatic (Docker Configs)
+
+Borgmatic runs daily at 3 AM and backs up all Docker Compose files, environment files, and persistent volumes. BorgBackup handles deduplication and compression, so incremental backups are fast and storage-efficient.
+
+**What it covers:**
+- Docker Compose configurations
+- Application data volumes
+- Environment files and secrets
+- Custom scripts and cron jobs
+
+### vzdump to PBS (VMs & Containers)
+
+Proxmox's built-in vzdump runs daily at 2 AM, creating full snapshots of every VM and LXC container. These snapshots are stored on Proxmox Backup Server (PBS) running in CT 104.
+
+**What it covers:**
+- Complete VM disk images
+- LXC container filesystems
+- Proxmox configuration
+
+### 3-2-1 Strategy
+
+I follow the 3-2-1 backup rule:
+- **3 copies** of all critical data
+- **2 different media types** (NVMe + USB HDD + PBS)
+- **1 offsite** backup (encrypted, pushed to remote storage)
+
+Retention policies keep daily backups for 7 days, weekly for 4 weeks, and monthly for 6 months.
+
+## Jellyfin & Jellyseerr
+
+Jellyfin is my self-hosted media server, streaming my personal library to any device on the network. It handles hardware-accelerated transcoding for smooth playback on lower-powered clients.
+
+Jellyseerr sits in front of it as a request and discovery portal — it provides a clean UI for browsing, searching, and organizing the library. Multi-user support means family members get their own profiles and watch history.
+
+Everything runs in the media Docker stack on VM 100, with media files stored on the 4 TB USB HDD.
+
+## Uptime Kuma
+
+Uptime Kuma monitors every service in the homelab. It runs HTTP, TCP, and ping checks on configurable intervals and sends instant Telegram alerts when something goes down.
+
+The public status page at [status.homelab.seif-dx.com](https://status.homelab.seif-dx.com) gives a real-time view of service health. I also wrote a custom health check script that verifies not just that containers are running, but that they're actually responding correctly.
+
+Key monitors include:
+- All reverse-proxied services (HTTP 200 checks)
+- DNS resolution (AdGuard primary and replica)
+- Backup job completion (via webhook)
+- VPN tunnel status
+- Disk space and memory thresholds
+
+## VPN Gateway
+
+The VPN setup has two layers:
+
+### Gluetun (Outbound VPN)
+
+Gluetun runs as a Docker container providing a WireGuard tunnel for services that need VPN-routed outbound traffic. It includes a kill switch that blocks all traffic if the tunnel drops, preventing any leaks. Services connect through Gluetun's network stack using Docker's `network_mode: "service:gluetun"` pattern.
+
+### Tailscale (Remote Access)
+
+Tailscale runs in its own LXC container (CT 102) and provides mesh VPN access to the entire homelab from anywhere. Whether I'm on my phone, laptop, or a remote server, I can reach every service as if I were on the local network.
+
+Tailscale also enables:
+- SSH access without exposing port 22 to the internet
+- Sharing specific services with friends/family via Tailscale Funnel
+- Exit node functionality for routing all traffic through the homelab
+
+## AdGuard Home
+
+DNS filtering runs on two dedicated LXC containers:
+
+- **CT 101 — Primary**: Handles all DNS queries with custom filter lists
+- **CT 103 — Replica**: Syncs configuration from the primary for redundancy
+
+Both instances use DNS-over-HTTPS upstream resolvers for privacy. The Proxmox host runs iptables DNAT rules that intercept all outbound DNS traffic (port 53) and redirect it to the primary AdGuard instance. This means even devices with hardcoded DNS servers (smart TVs, IoT devices) go through filtering.
+
+Filter lists include:
+- Standard ad and tracker blocking
+- Malware and phishing domain lists
+- Custom rules for specific services
+
+The replica ensures DNS continues working even during primary maintenance or updates.
+
+## Security: CrowdSec WAF & Caddy
+
+Security is multi-layered:
+
+### Caddy (Reverse Proxy)
+
+Caddy handles all incoming HTTPS traffic. It uses the Cloudflare DNS-01 challenge for automatic TLS certificate provisioning, which means I never expose port 80 for HTTP-01 challenges. Wildcard certificates cover all subdomains.
+
+### CrowdSec (WAF)
+
+CrowdSec is the collaborative security layer. It analyzes Caddy's access logs in real-time and blocks malicious IPs based on:
+
+- **Local decisions**: Detected attacks against my infrastructure (brute force, path scanning, exploit attempts)
+- **Community blocklists**: Shared threat intelligence from thousands of other CrowdSec users
+
+The CrowdSec bouncer integrates directly with Caddy, blocking bad actors at the reverse proxy level before requests ever reach backend services.
+
+### Defense in Depth
+
+The full security stack:
+1. **Cloudflare** — DDoS protection, rate limiting at the edge
+2. **Caddy** — TLS termination, header hardening
+3. **CrowdSec** — WAF, community threat intelligence
+4. **AdGuard** — DNS-level filtering
+5. **Tailscale** — Zero-trust remote access (no exposed SSH)
+6. **Gluetun** — VPN kill switch for outbound traffic
+
+## Conclusion
+
+Building this homelab has been one of the most rewarding projects I've worked on. Every service I add deepens my understanding of networking, Linux administration, containerization, and security. The 3-2-1 backup strategy means I can recover from any failure, and the monitoring setup means I know about problems before they become outages.
+
+If you're considering building your own homelab, start small — a single Docker host with Caddy and one or two services is enough to learn the fundamentals. The complexity grows naturally as your needs expand.
+
+The full stack is visible on my [portfolio homelab section](/#homelab), and you can check real-time service status on the [status page](https://status.homelab.seif-dx.com).

--- a/data/homelab.ts
+++ b/data/homelab.ts
@@ -1,0 +1,124 @@
+export interface HomelabService {
+    id: string
+    title: string
+    description: string
+    icon: string
+    technologies: string[]
+    features: string[]
+    category: "infrastructure" | "media" | "security" | "backup"
+}
+
+export const homelabServices: HomelabService[] = [
+    {
+        id: "proxmox",
+        title: "Proxmox VE",
+        description:
+            "Type-1 hypervisor running on a 16-core / 30 GB RAM host with 4 TB USB HDD storage. Manages LXC containers and VMs across two bridges: vmbr0 (LAN) and vmbr1 (private NAT 10.10.10.0/24).",
+        icon: "🖥️",
+        technologies: ["Proxmox VE", "LXC", "KVM", "ZFS", "Debian"],
+        features: [
+            "LXC containers for AdGuard, Tailscale, PBS",
+            "VM 100 Docker host for all service stacks",
+            "Dual bridge networking (LAN + private NAT)",
+            "DNS forwarding via iptables to AdGuard",
+        ],
+        category: "infrastructure",
+    },
+    {
+        id: "caddy-crowdsec",
+        title: "Caddy + CrowdSec",
+        description:
+            "Reverse proxy with automatic TLS via Cloudflare DNS challenge, paired with CrowdSec WAF for collaborative threat intelligence and DDoS protection.",
+        icon: "🔒",
+        technologies: ["Caddy", "CrowdSec", "Cloudflare", "Let's Encrypt"],
+        features: [
+            "Auto TLS with Cloudflare DNS-01 challenge",
+            "CrowdSec WAF with community blocklists",
+            "Rate limiting and DDoS protection",
+            "Wildcard certificates for all subdomains",
+        ],
+        category: "security",
+    },
+    {
+        id: "adguard",
+        title: "AdGuard Home",
+        description:
+            "Network-wide DNS filtering with a primary + replica setup running in dedicated LXC containers. All DNS traffic is forwarded via iptables rules.",
+        icon: "🛡️",
+        technologies: ["AdGuard Home", "DNS", "LXC", "iptables"],
+        features: [
+            "Primary (CT 101) + Replica (CT 103) for redundancy",
+            "Network-wide ad and tracker blocking",
+            "DNS-over-HTTPS upstream resolvers",
+            "iptables DNAT rules for forced DNS redirection",
+        ],
+        category: "security",
+    },
+    {
+        id: "jellyfin",
+        title: "Jellyfin & Jellyseerr",
+        description:
+            "Self-hosted media streaming server for personal library with a request portal for managing new content additions.",
+        icon: "🎬",
+        technologies: ["Jellyfin", "Jellyseerr", "Docker", "FFmpeg"],
+        features: [
+            "Hardware-accelerated transcoding",
+            "Multi-user streaming with profiles",
+            "Jellyseerr request portal for content management",
+            "Organized media library with metadata scraping",
+        ],
+        category: "media",
+    },
+    {
+        id: "vpn-gateway",
+        title: "WireGuard VPN Gateway",
+        description:
+            "VPN tunneling via Gluetun container for secure outbound traffic, combined with Tailscale (CT 102) for remote access to the entire homelab.",
+        icon: "🌐",
+        technologies: ["WireGuard", "Gluetun", "Tailscale", "LXC"],
+        features: [
+            "Gluetun container for VPN-tunneled services",
+            "Tailscale mesh VPN for remote homelab access",
+            "Kill switch preventing traffic leaks",
+            "Split tunneling for selective routing",
+        ],
+        category: "security",
+    },
+    {
+        id: "backups",
+        title: "Automated Backups",
+        description:
+            "Dual backup strategy: Borgmatic for Docker configs (daily 3 AM) and vzdump to Proxmox Backup Server (daily 2 AM) for VMs and containers.",
+        icon: "💾",
+        technologies: ["Borgmatic", "BorgBackup", "PBS", "vzdump"],
+        features: [
+            "Borgmatic: daily 3 AM, Docker configs + volumes",
+            "vzdump: daily 2 AM, full VM/CT snapshots to PBS (CT 104)",
+            "3-2-1 strategy: local + PBS + offsite",
+            "Configurable retention policies",
+        ],
+        category: "backup",
+    },
+    {
+        id: "uptime-kuma",
+        title: "Uptime Kuma",
+        description:
+            "Self-hosted monitoring dashboard tracking all services with health checks, response time graphs, and instant Telegram alerts on downtime.",
+        icon: "📊",
+        technologies: ["Uptime Kuma", "Docker", "Telegram API"],
+        features: [
+            "HTTP/TCP/Ping health checks for all services",
+            "Telegram instant alerts on downtime",
+            "Public status page for transparency",
+            "Response time graphs and uptime history",
+        ],
+        category: "infrastructure",
+    },
+]
+
+export const categoryColors: Record<HomelabService["category"], string> = {
+    infrastructure: "bg-blue-500/10 text-blue-400 border-blue-500/20",
+    media: "bg-purple-500/10 text-purple-400 border-purple-500/20",
+    security: "bg-green-500/10 text-green-400 border-green-500/20",
+    backup: "bg-amber-500/10 text-amber-400 border-amber-500/20",
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -14,7 +14,7 @@ export const BLOG_CONFIG = {
 // Site Configuration
 export const SITE_CONFIG = {
   EMAIL: "seif-dx@proton.me",
-  BASE_URL: process.env.NEXT_PUBLIC_FRONTEND_URL!,
+  BASE_URL: process.env.NEXT_PUBLIC_FRONTEND_URL || "https://seif-dx.com",
   AUTHOR: "Seif-DX",
   TITLE: "Seif-DX Portfolio",
 } as const;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,9 +13,15 @@ export const BLOG_CONFIG = {
 
 // Site Configuration
 export const SITE_CONFIG = {
-  EMAIL: "ismailseifeldin54@gmail.com",
-  BASE_URL:
-    process.env.NEXT_PUBLIC_FRONTEND_URL || "https://www.seifeldinismail.com",
+  EMAIL: "seif-dx@proton.me",
+  BASE_URL: process.env.NEXT_PUBLIC_FRONTEND_URL!,
   AUTHOR: "Seif-DX",
   TITLE: "Seif-DX Portfolio",
+} as const;
+
+// External Links
+export const LINKS = {
+  GITHUB: "https://github.com/Seifeldin-Sabry",
+  LINKEDIN: "https://www.linkedin.com/in/seif-sabry-b8a542202/",
+  CALENDLY: "https://calendly.com/ismailseifeldin54/45min",
 } as const;

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -1,3 +1,0 @@
-export const githubLink = "https://github.com/Seifeldin-Sabry"
-export const linkedInLink = "https://www.linkedin.com/in/seif-sabry-b8a542202/"
-export const calendlyLink = "https://calendly.com/ismailseifeldin54/45min"


### PR DESCRIPTION
## Summary
- Add collapsible Homelab section with 7 expandable service cards (Proxmox, Caddy+CrowdSec, AdGuard, Jellyfin, WireGuard, Backups, Uptime Kuma)
- Embed Uptime Kuma status page iframe when the monitoring card is expanded
- Add blog post covering the full homelab infrastructure setup
- Merge `lib/links.ts` into `lib/constants.ts` as a `LINKS` const object

## Test plan
- [ ] `npm run dev` — homelab section renders between Projects and Experience
- [ ] Section is collapsed by default, click header to expand
- [ ] Click each service card — expands with details, only one at a time
- [ ] Uptime Kuma iframe appears only when the Uptime Kuma card is expanded
- [ ] Visit `/blog/homelab-setup` — blog renders correctly
- [ ] Blog appears in Writing section list
- [ ] Profile section links still work after links.ts merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive Homelab section with collapsible service cards, expandable details, tech badges, and a live uptime status embed.

* **Documentation**
  * Added a detailed blog post describing a Proxmox-based homelab setup, networking, security, monitoring, and backup strategies.

* **Chores**
  * Updated contact email and consolidated social links into a single source for profile links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->